### PR TITLE
chore(RHTAPWATCH-1185): Refresh client before sending messages

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/konflux-ci/notification-service/internal/controller"
 	"github.com/konflux-ci/notification-service/pkg/notifier"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -123,15 +124,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	snsClient, err := notifier.NewSNSClient()
-	if err != nil {
-		setupLog.Error(err, "Error creating notifier")
-		os.Exit(1)
-	}
+	var snsClient *sns.Client
 
 	ntf := &notifier.SNSNotifier{
-		Pub: snsClient,
-		Log: mgr.GetLogger(),
+		Pub:           snsClient,
+		RefreshClient: notifier.RefreshClient,
+		Log:           mgr.GetLogger(),
 	}
 
 	if err = (&controller.NotificationServiceReconciler{

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-logr/logr"
 )
 
+type ClientRefresher func() (Publisher, error)
+
 type Notifier interface {
 	Notify(context.Context, string) error
 }
@@ -22,24 +24,28 @@ type Publisher interface {
 }
 
 type SNSNotifier struct {
-	Pub Publisher
-	Log logr.Logger
+	Pub           Publisher
+	RefreshClient ClientRefresher
+	Log           logr.Logger
 }
 
-var logger logr.Logger
-
 /*
-To create the client, make sure you set the
-AWS credentials as environment variables:
-AWS_ACCESS_KEY_ID,
-AWS_SECRET_ACCESS_KEY,
-AWS_SESSION_TOKEN (optional)
+To create the client, make sure you set a secret with AWS credentials
+Set the key to be `credentials`
+Set the value to be
+`[default]
+aws_access_key_id=<AWS_ACCESS_KEY>
+aws_secret_access_key=<AWS_SECRET_ACCESS_KEY>`
+
+Set the values to match your credentials
+Mount the secret to `/.aws`
+
 In addition, make sure you also set the
-NOTIFICATION_REGION for the region,
-NOTIFICATION_TOPIC_ARN for the SNS topic ARN
+`NOTIFICATION_REGION` environment variable for the region,
+and `NOTIFICATION_TOPIC_ARN` environment variable for the SNS topic ARN
 */
 
-func NewSNSClient() (*sns.Client, error) {
+func RefreshClient() (Publisher, error) {
 	region := os.Getenv("NOTIFICATION_REGION")
 	sdkConfig, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
 	if err != nil {
@@ -50,9 +56,15 @@ func NewSNSClient() (*sns.Client, error) {
 
 func (s *SNSNotifier) Notify(ctx context.Context, message string) error {
 	logger := s.Log.WithName("Notifier")
+	cli, err := s.RefreshClient()
+	if err != nil {
+		logger.Error(err, "Could not create sns client")
+		return err
+	}
+	s.Pub = cli
 	topicArn := os.Getenv("NOTIFICATION_TOPIC_ARN")
 	publishInput := sns.PublishInput{TopicArn: aws.String(topicArn), Message: aws.String(message)}
-	_, err := s.Pub.Publish(ctx, &publishInput)
+	_, err = s.Pub.Publish(ctx, &publishInput)
 	if err != nil {
 		logger.Error(err, "Could not send notification to SNS")
 		return err


### PR DESCRIPTION
Since we will obtain the AWS credentials from a secret mounted to our pod, we will need to refresh the client before `Notify` action will take place to make sure we are creating a client with the most recent secret.

In this PR:  
- Refresh client before sending message in order to obtain the most recent secret (in case of secret updates)
- Adding tests