### PR TITLE
add status of ended pipelinerun to the log

### DIFF
--- a/internal/controller/notificationservice_controller.go
+++ b/internal/controller/notificationservice_controller.go
@@ -70,6 +70,7 @@ func (r *NotificationServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 
 	if IsPipelineRunEnded(pipelineRun) {
+		logger.Info("Pipelinerun ended", "pipelinerun", pipelineRun.Name, "ended_successfully", IsPipelineRunEndedSuccessfully(pipelineRun))
 		if IsPipelineRunEndedSuccessfully(pipelineRun) && !IsAnnotationExistInPipelineRun(pipelineRun, NotificationPipelineRunAnnotation, NotificationPipelineRunAnnotationValue) {
 			results, err := GetResultsFromPipelineRun(pipelineRun)
 			if err != nil {


### PR DESCRIPTION
While checking the logs in staging I found several pipelineruns that did not send notifications.
Those pipelineruns ended not successfully and do not need to send message.

Adding the status of ended pipelinerun to the log to better understand from the logs whether a message should be sent or not, very effective after pipelineruns are deleted and we have no way of knowing they failed.

Logs will look like:

`2024-08-08T08:25:26Z INFO Notification controller Pipelinerun ended {"pipelinerun": "dummy-push-pipelinerun-2qkt5", "ended_successfully": true}`

`2024-08-08T08:27:08Z INFO Notification controller Pipelinerun ended {"pipelinerun": "dummy-push-pipelinerun-4dqlg", "ended_successfully": false}`

