### PR TITLE
config: update Renovate schedule for more frequent testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+  "schedule": ["at any time"],
   "automergeStrategy": "merge-commit",
   "platformAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
Change renovate.json schedule from default to 'at any time' to get quicker mintmaker prs for testing