### PR TITLE
fix: increase memory limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,9 +69,9 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 1000m
-            memory: 512Mi
+            memory: 1Gi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
 increase memory limit from 512Mi to 1Gi to resolve OOMKilled crashes