### PR TITLE
fix(renovate): exclude problematic dependencies from go grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,12 @@
       "description": "Group Go dependencies for manual review",
       "groupName": "go-dependencies",
       "matchDatasources": ["go"],
+      "excludePackageNames": [
+        "github.com/google/cel-go",
+        "github.com/konflux-ci/operator-toolkit",
+        "knative.dev/pkg",
+        "github.com/tektoncd/pipeline"
+      ],
       "automerge": false,
       "autoApprove": false
     },


### PR DESCRIPTION
Exclude packages that cause failures from grouped dependency updates