### PR TITLE
chore: remove grouping of go packages in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,30 +43,6 @@
       "autoApprove": true
     },
     {
-      "description": "Group Kubernetes ecosystem dependencies to prevent version conflicts",
-      "groupName": "kubernetes-ecosystem",
-      "matchPackagePatterns": [
-        "^k8s.io/",
-        "^sigs.k8s.io/"
-      ],
-      "matchDatasources": ["go"],
-      "automerge": false,
-      "autoApprove": false
-    },
-    {
-      "description": "Group Go dependencies for manual review",
-      "groupName": "go-dependencies",
-      "matchDatasources": ["go"],
-      "excludePackageNames": [
-        "github.com/google/cel-go",
-        "github.com/konflux-ci/operator-toolkit",
-        "knative.dev/pkg",
-        "github.com/tektoncd/pipeline"
-      ],
-      "automerge": false,
-      "autoApprove": false
-    },
-    {
       "matchPackageNames": [
         "quay.io/konflux-ci/*",
         "registry.access.redhat.com/ubi9/ubi-minimal"


### PR DESCRIPTION
As failures are quite common for renovate PRs for go updates, having upgrades grouped makes it harder to get those PRs merged.

Ungrouping should allow us to merge the ones that don't cause trouble and to more easily troubleshoot the ones that do.