### PR TITLE
chore(deps): auto-merge non-major Go updates and disable indirect major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,20 @@
       ]
     },
     {
+      "description": "Disable major version updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Auto-merge non-major Go module updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
       "description": "Auto-merge Go toolchain patch updates only",
       "matchPackageNames": [
         "go"


### PR DESCRIPTION
Reduce toil from manually reviewing and merging minor, patch, and digest Go dependency bumps. Major updates still require manual review to catch breaking changes. Indirect major updates are disabled since they are resolved by go mod tidy based on direct dependency requirements.

Assisted-by: Claude claude-opus-4-6