### PR TITLE
fix(KONFLUX-13346): Make PipelineRun filtering configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ be sent to and the `region` of the AWS account.
 | NOTIFICATION_REGION | define the AWS region to use
 | NOTIFICATION_TOPIC_ARN | the topic arn the messages will be sent to
 
+## Configure PipelineRun Filtering
+
+By default, the controller only processes PipelineRuns with the label `pipelinesascode.tekton.dev/event-type=push`. 
+This can be customized using the following optional environment variables:
+
+| Name | Description | Example |
+| -- | -- | -- |
+| NOTIFICATION_FILTER_LABELS | Comma-separated list of label key=value pairs to filter PipelineRuns | `pipelinesascode.tekton.dev/event-type=push` |
+| NOTIFICATION_FILTER_ANNOTATIONS | Comma-separated list of annotation keys to filter PipelineRuns by presence | `my-custom-annotation` |
+
+**Note:** If both variables are unset, the controller defaults to filtering by the label key-value pair `pipelinesascode.tekton.dev/event-type=push`. 
+If either variable is set, only PipelineRuns matching the configured filters will be processed.
+
 ## Running, building and testing the controller
 
 This controller provides a [Makefile](Makefile) to run all the usual development tasks. This file can be used by cloning

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,16 +39,21 @@ spec:
         - /manager
         args:
         - --health-probe-bind-address=:8081
-        - --metrics-secure=true         
+        - --metrics-secure=true
         image: controller:latest
         name: manager
+        env:
+        - name: NOTIFICATION_FILTER_LABELS
+          value: "pipelinesascode.tekton.dev/event-type=push"
+        - name: NOTIFICATION_FILTER_ANNOTATIONS
+          value: ""
         volumeMounts:
         - name: vol-secret
           mountPath: /.aws
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
-          runAsNonRoot: true          
+          runAsNonRoot: true
           capabilities:
             drop:
             - "ALL"

--- a/internal/controller/notificationservice_controller.go
+++ b/internal/controller/notificationservice_controller.go
@@ -120,10 +120,10 @@ func (r *NotificationServiceReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&tektonv1.PipelineRun{}).
 		WithEventFilter(predicate.Or(
-			PushPipelineRunCreatedPredicate(),
-			PushPipelineRunEndedFinalizerPredicate(),
-			PushPipelineRunEndedNoAnnotationPredicate(),
-			PushPipelineRunDeletingPredicate(),
+			PipelineRunCreatedPredicate(),
+			PipelineRunEndedFinalizerPredicate(),
+			PipelineRunEndedNoAnnotationPredicate(),
+			PipelineRunDeletingPredicate(),
 		)).
 		Complete(r)
 }

--- a/internal/controller/notificationservice_controller_test.go
+++ b/internal/controller/notificationservice_controller_test.go
@@ -153,9 +153,9 @@ var _ = Describe("NotificationService Controller", func() {
 					Eventually(func() bool {
 						err := k8sClient.Get(ctx, pushPipelineRunLookupKey, createdPipelineRun)
 						Expect(err).ToNot(HaveOccurred())
-						return metadata.HasAnnotationWithValue(createdPipelineRun, NotificationPipelineRunAnnotation, NotificationPipelineRunAnnotationValue)
+						return metadata.HasAnnotationWithValue(createdPipelineRun, NotificationPipelineRunAnnotation, NotificationPipelineRunAnnotationValue) &&
+							!controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)
 					}, timeout, interval).Should(BeTrue())
-					Expect(controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)).To(BeFalse())
 					// Check the Notify was called only once
 					Expect(mn.Counter).To(Equal(1))
 					// Check that notifications metric increased by 1
@@ -417,6 +417,67 @@ var _ = Describe("NotificationService Controller", func() {
 			})
 		})
 	})
+	Describe("Testing annotation-based filtering", func() {
+		const annotatedPipelineRunName = "annotated-pipelinerun-sample"
+		annotatedPipelineRunLookupKey := types.NamespacedName{Name: annotatedPipelineRunName, Namespace: namespace}
+
+		Context("when a PipelineRun matches the annotation filter", func() {
+			It("should reconcile and process the PipelineRun", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger")
+
+				err := nsr.SetupWithManager(k8sManager)
+				Expect(err).ToNot(HaveOccurred())
+
+				notificationsCounter = testutil.ToFloat64(notifications)
+
+				annotatedPipelineRun := &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      annotatedPipelineRunName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"custom-build-trigger": "https://ci.example.com/build/123",
+						},
+						Labels: map[string]string{
+							"appstudio.openshift.io/application": "test-app",
+						},
+					},
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{},
+					},
+					Status: tektonv1.PipelineRunStatus{
+						PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+							StartTime:      &metav1.Time{Time: time.Now()},
+							CompletionTime: &metav1.Time{Time: time.Now().Add(5 * time.Minute)},
+						},
+						Status: v1.Status{
+							Conditions: v1.Conditions{
+								apis.Condition{
+									Message: "Tasks Completed: 3 (Failed: 0, Cancelled 0), Incomplete: 10, Skipped:1",
+									Reason:  "Running",
+									Status:  "Unknown",
+									Type:    apis.ConditionSucceeded,
+								},
+							},
+						},
+					},
+				}
+				err = k8sClient.Create(ctx, annotatedPipelineRun)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, annotatedPipelineRunLookupKey, createdPipelineRun)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, annotatedPipelineRunLookupKey, createdPipelineRun)
+					Expect(err).ToNot(HaveOccurred())
+					return controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+	})
+
 	AfterEach(func() {
 		err := k8sClient.Delete(ctx, createdPipelineRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())

--- a/internal/controller/notificationservice_controller_test.go
+++ b/internal/controller/notificationservice_controller_test.go
@@ -153,9 +153,9 @@ var _ = Describe("NotificationService Controller", func() {
 					Eventually(func() bool {
 						err := k8sClient.Get(ctx, pushPipelineRunLookupKey, createdPipelineRun)
 						Expect(err).ToNot(HaveOccurred())
-						return metadata.HasAnnotationWithValue(createdPipelineRun, NotificationPipelineRunAnnotation, NotificationPipelineRunAnnotationValue)
+						return metadata.HasAnnotationWithValue(createdPipelineRun, NotificationPipelineRunAnnotation, NotificationPipelineRunAnnotationValue) &&
+							!controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)
 					}, timeout, interval).Should(BeTrue())
-					Expect(controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)).To(BeFalse())
 					// Check the Notify was called only once
 					Expect(mn.Counter).To(Equal(1))
 					// Check that notifications metric increased by 1
@@ -417,6 +417,65 @@ var _ = Describe("NotificationService Controller", func() {
 			})
 		})
 	})
+	Describe("Testing annotation-based filtering", func() {
+		const annotatedPipelineRunName = "annotated-pipelinerun-sample"
+		annotatedPipelineRunLookupKey := types.NamespacedName{Name: annotatedPipelineRunName, Namespace: namespace}
+
+		Context("when a PipelineRun matches the annotation filter", func() {
+			It("should reconcile and process the PipelineRun", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger")
+
+				err := nsr.SetupWithManager(k8sManager)
+				Expect(err).ToNot(HaveOccurred())
+
+				annotatedPipelineRun := &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      annotatedPipelineRunName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"custom-build-trigger": "https://ci.example.com/build/123",
+						},
+						Labels: map[string]string{
+							"appstudio.openshift.io/application": "test-app",
+						},
+					},
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{},
+					},
+					Status: tektonv1.PipelineRunStatus{
+						PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+							StartTime:      &metav1.Time{Time: time.Now()},
+							CompletionTime: &metav1.Time{Time: time.Now().Add(5 * time.Minute)},
+						},
+						Status: v1.Status{
+							Conditions: v1.Conditions{
+								apis.Condition{
+									Message: "Tasks Completed: 3 (Failed: 0, Cancelled 0), Incomplete: 10, Skipped:1",
+									Reason:  "Running",
+									Status:  "Unknown",
+									Type:    apis.ConditionSucceeded,
+								},
+							},
+						},
+					},
+				}
+				err = k8sClient.Create(ctx, annotatedPipelineRun)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, annotatedPipelineRunLookupKey, createdPipelineRun)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, annotatedPipelineRunLookupKey, createdPipelineRun)
+					Expect(err).ToNot(HaveOccurred())
+					return controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+	})
+
 	AfterEach(func() {
 		err := k8sClient.Delete(ctx, createdPipelineRun)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())

--- a/internal/controller/pipelinerun_helper.go
+++ b/internal/controller/pipelinerun_helper.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/konflux-ci/operator-toolkit/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -133,14 +136,45 @@ func IsAnnotationExistInPipelineRun(object client.Object, annotation string, ann
 	return false
 }
 
-// IsPushPipelineRun checks if an object is a push pipelinerun
-// Return true if yes, otherwise return false
-// If the object passed to this function is not a PipelineRun, the function will return false.
-func IsPushPipelineRun(object client.Object) bool {
-	if pipelineRun, ok := object.(*tektonv1.PipelineRun); ok {
-		return metadata.HasLabelWithValue(pipelineRun,
-			PipelineRunTypeLabel,
-			PushPipelineRunTypeValue)
+// ShouldProcessPipelineRun checks whether a PipelineRun matches the filters configured via
+// NOTIFICATION_FILTER_LABELS and NOTIFICATION_FILTER_ANNOTATIONS. Defaults to push-only when both are unset.
+func ShouldProcessPipelineRun(object client.Object) bool {
+	pipelineRun, ok := object.(*tektonv1.PipelineRun)
+	if !ok {
+		return false
+	}
+
+	filterLabels := os.Getenv("NOTIFICATION_FILTER_LABELS")
+	filterAnnotations := os.Getenv("NOTIFICATION_FILTER_ANNOTATIONS")
+
+	if filterLabels == "" && filterAnnotations == "" {
+		return metadata.HasLabelWithValue(pipelineRun, PipelineRunTypeLabel, PushPipelineRunTypeValue)
+	}
+
+	if filterLabels != "" {
+		labelPairs := strings.Split(filterLabels, ",")
+		for _, pair := range labelPairs {
+			pair = strings.TrimSpace(pair)
+			parts := strings.SplitN(pair, "=", 2)
+			if len(parts) != 2 {
+				ctrl.Log.Info("Ignoring malformed label filter entry, expected key=value format", "entry", pair)
+				continue
+			}
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			if metadata.HasLabelWithValue(pipelineRun, key, value) {
+				return true
+			}
+		}
+	}
+
+	if filterAnnotations != "" {
+		for _, key := range strings.Split(filterAnnotations, ",") {
+			key = strings.TrimSpace(key)
+			if metadata.HasAnnotation(pipelineRun, key) {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/internal/controller/pipelinerun_helper_test.go
+++ b/internal/controller/pipelinerun_helper_test.go
@@ -90,8 +90,8 @@ var _ = Describe("Unit testing for pipelinerun_helper", func() {
 			},
 		}
 		Context("when a push pipelinerun ends successfully and has results", func() {
-			It("IsPushPipelineRun should return true", func() {
-				got := IsPushPipelineRun(testTruePipelineRun)
+			It("ShouldProcessPipelineRun should return true", func() {
+				got := ShouldProcessPipelineRun(testTruePipelineRun)
 				Expect(got).To(BeTrue())
 			})
 			It("IsAnnotationExistInPipelineRun should return true", func() {
@@ -189,8 +189,8 @@ var _ = Describe("Unit testing for pipelinerun_helper", func() {
 			},
 		}
 		Context("when a pull_request pipelinerun is created, Still running and has no results", func() {
-			It("IsPushPipelineRun should return false", func() {
-				got := IsPushPipelineRun(testFalsePipelineRun)
+			It("ShouldProcessPipelineRun should return false", func() {
+				got := ShouldProcessPipelineRun(testFalsePipelineRun)
 				Expect(got).To(BeFalse())
 			})
 			It("IsAnnotationExistInPipelineRun shouldreturn false", func() {
@@ -260,8 +260,8 @@ var _ = Describe("Unit testing for pipelinerun_helper", func() {
 			},
 		}
 		Context("When non pipelinerun object created", func() {
-			It("IsPushPipelineRun should return false", func() {
-				got := IsPushPipelineRun(notPipelineRun)
+			It("ShouldProcessPipelineRun should return false", func() {
+				got := ShouldProcessPipelineRun(notPipelineRun)
 				Expect(got).To(BeFalse())
 			})
 			It("IsAnnotationExistInPipelineRun should return false", func() {
@@ -515,6 +515,133 @@ var _ = Describe("Unit testing for pipelinerun_helper", func() {
 			It("RemoveFinalizerFromPipelineRun should return an error", func() {
 				err := RemoveFinalizerFromPipelineRun(ctx, testPipelineRun, fakeErrorNsr, NotificationPipelineRunFinalizer)
 				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("ShouldProcessPipelineRun filtering tests", func() {
+		var (
+			pushPipelineRun,
+			annotatedPipelineRun,
+			noPipelineRun *tektonv1.PipelineRun
+		)
+
+		BeforeEach(func() {
+			// PipelineRun with push label (default case)
+			pushPipelineRun = &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "push-pipeline",
+					Namespace: namespace,
+					Labels: map[string]string{
+						PipelineRunTypeLabel: PushPipelineRunTypeValue,
+					},
+				},
+			}
+
+			// PipelineRun with custom-build-trigger annotation
+			annotatedPipelineRun = &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "annotated-pipeline",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"custom-build-trigger": "https://ci.example.com/build/123",
+					},
+				},
+			}
+
+			// PipelineRun with no relevant labels or annotations
+			noPipelineRun = &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-filter-pipeline",
+					Namespace: namespace,
+				},
+			}
+		})
+
+		Context("Default filtering (no env vars set)", func() {
+			It("should process push PipelineRuns", func() {
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeTrue())
+			})
+
+			It("should not process annotated PipelineRuns without push label", func() {
+				Expect(ShouldProcessPipelineRun(annotatedPipelineRun)).To(BeFalse())
+			})
+
+			It("should not process PipelineRuns without event-type label", func() {
+				Expect(ShouldProcessPipelineRun(noPipelineRun)).To(BeFalse())
+			})
+		})
+
+		Context("Label filtering with NOTIFICATION_FILTER_LABELS", func() {
+			It("should process push PipelineRuns when filter matches", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", "pipelinesascode.tekton.dev/event-type=push")
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeTrue())
+			})
+
+			It("should not process PipelineRuns without matching label", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", "pipelinesascode.tekton.dev/event-type=push")
+				Expect(ShouldProcessPipelineRun(annotatedPipelineRun)).To(BeFalse())
+			})
+		})
+
+		Context("Annotation filtering with NOTIFICATION_FILTER_ANNOTATIONS", func() {
+			It("should process PipelineRuns when annotation filter matches", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger")
+				Expect(ShouldProcessPipelineRun(annotatedPipelineRun)).To(BeTrue())
+			})
+
+			It("should not process PipelineRuns without matching annotation", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger")
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeFalse())
+			})
+
+			It("should handle multiple annotation filters", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger,custom-annotation")
+				Expect(ShouldProcessPipelineRun(annotatedPipelineRun)).To(BeTrue())
+			})
+		})
+
+		Context("Combined label and annotation filtering", func() {
+			It("should process PipelineRuns matching either label or annotation", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", "pipelinesascode.tekton.dev/event-type=push")
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger")
+
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeTrue())
+				Expect(ShouldProcessPipelineRun(annotatedPipelineRun)).To(BeTrue())
+			})
+
+			It("should not process PipelineRuns matching neither filter", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", "pipelinesascode.tekton.dev/event-type=push")
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "custom-build-trigger")
+
+				Expect(ShouldProcessPipelineRun(noPipelineRun)).To(BeFalse())
+			})
+		})
+
+		Context("Edge cases", func() {
+			It("should return false for non-PipelineRun objects", func() {
+				taskRun := &tektonv1.TaskRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-taskrun",
+					},
+				}
+				Expect(ShouldProcessPipelineRun(taskRun)).To(BeFalse())
+			})
+
+			It("should handle empty filter values gracefully", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", "")
+				GinkgoT().Setenv("NOTIFICATION_FILTER_ANNOTATIONS", "")
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeTrue())
+			})
+
+			It("should handle whitespace in filter configuration", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", " pipelinesascode.tekton.dev/event-type=push ")
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeTrue())
+			})
+
+			It("should return false when label filter has no '=' separator", func() {
+				GinkgoT().Setenv("NOTIFICATION_FILTER_LABELS", "badfilter")
+				Expect(ShouldProcessPipelineRun(pushPipelineRun)).To(BeFalse())
 			})
 		})
 	})

--- a/internal/controller/predicates.go
+++ b/internal/controller/predicates.go
@@ -5,12 +5,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// PushPipelineRunCreatedPredicate returns a predicate which filters out all objects except
-// Push PipelineRuns that have just created
-func PushPipelineRunCreatedPredicate() predicate.Predicate {
+// PipelineRunCreatedPredicate returns a predicate which filters out all objects except
+// PipelineRuns matching the configured filters that have just been created
+func PipelineRunCreatedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
-			return IsPushPipelineRun(createEvent.Object)
+			return ShouldProcessPipelineRun(createEvent.Object)
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return false
@@ -24,9 +24,9 @@ func PushPipelineRunCreatedPredicate() predicate.Predicate {
 	}
 }
 
-// PushPipelineRunEndedNoAnnotationPredicate returns a predicate which filters out all objects except
-// Push PipelineRuns which have finished and has no notification annotation
-func PushPipelineRunEndedNoAnnotationPredicate() predicate.Predicate {
+// PipelineRunEndedNoAnnotationPredicate returns a predicate which filters out all objects except
+// matching PipelineRuns which have finished and have no notification annotation
+func PipelineRunEndedNoAnnotationPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -38,16 +38,16 @@ func PushPipelineRunEndedNoAnnotationPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return (IsPushPipelineRun(e.ObjectNew) &&
+			return (ShouldProcessPipelineRun(e.ObjectNew) &&
 				IsPipelineRunEnded(e.ObjectNew) &&
 				!IsAnnotationExistInPipelineRun(e.ObjectNew, NotificationPipelineRunAnnotation, NotificationPipelineRunAnnotationValue))
 		},
 	}
 }
 
-// PushPipelineRunEndedFinalizerPredicate returns a predicate which filters out all objects except
-// Push PipelineRuns which have finished and has finalizer
-func PushPipelineRunEndedFinalizerPredicate() predicate.Predicate {
+// PipelineRunEndedFinalizerPredicate returns a predicate which filters out all objects except
+// matching PipelineRuns which have finished and have a finalizer
+func PipelineRunEndedFinalizerPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -60,15 +60,15 @@ func PushPipelineRunEndedFinalizerPredicate() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return (IsFinalizerExistInPipelineRun(e.ObjectNew, NotificationPipelineRunFinalizer) &&
-				IsPushPipelineRun(e.ObjectNew) &&
+				ShouldProcessPipelineRun(e.ObjectNew) &&
 				IsPipelineRunEnded(e.ObjectNew))
 		},
 	}
 }
 
-// BuildPipelineRunDeletingPredicate returns a predicate which filters out all objects except
-// Build PipelineRuns which have been updated to deleting
-func PushPipelineRunDeletingPredicate() predicate.Predicate {
+// PipelineRunDeletingPredicate returns a predicate which filters out all objects except
+// matching PipelineRuns which have been updated to deleting
+func PipelineRunDeletingPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(createEvent event.CreateEvent) bool {
 			return false
@@ -80,7 +80,7 @@ func PushPipelineRunDeletingPredicate() predicate.Predicate {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if IsPushPipelineRun(e.ObjectNew) &&
+			if ShouldProcessPipelineRun(e.ObjectNew) &&
 				e.ObjectOld.GetDeletionTimestamp() == nil &&
 				e.ObjectNew.GetDeletionTimestamp() != nil {
 				return true


### PR DESCRIPTION
Add NOTIFICATION_FILTER_LABELS and NOTIFICATION_FILTER_ANNOTATIONS environment variables to allow processing both PipelinesAsCode and ART-initiated builds. ART builds were previously filtered out due to missing event-type=push label. Configure both filters to process mta-*, mtc-*, oadp-*, logging-* PipelineRuns.

Fixes: KONFLUX-13346

Co-Authored-By: Claude Code