### PR TITLE
fix(KONFLUX-13770): use optimistic lock for PLR finalizer patches

### DIFF
--- a/internal/controller/notificationservice_controller.go
+++ b/internal/controller/notificationservice_controller.go
@@ -68,6 +68,10 @@ func (r *NotificationServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 			logger.Info("Pipelinerun was deleted, removing finalizer", "Name", pipelineRun.Name)
 			err = RemoveFinalizerFromPipelineRun(ctx, pipelineRun, r, NotificationPipelineRunFinalizer)
 			if err != nil {
+				if errors.IsConflict(err) {
+					logger.Info("Conflict removing finalizer on deleted run, will retry on re-fetch", "pipelineRun", pipelineRun.Name)
+					return ctrl.Result{}, err
+				}
 				logger.Error(err, "Failed to remove finalizer", "pipelineRun", pipelineRun.Name)
 				return ctrl.Result{}, err
 			}
@@ -77,6 +81,10 @@ func (r *NotificationServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 			logger.Info("Pipelinerun is running, Trying to add finalizer", "Name", pipelineRun.Name)
 			err = AddFinalizerToPipelineRun(ctx, pipelineRun, r, NotificationPipelineRunFinalizer)
 			if err != nil {
+				if errors.IsConflict(err) {
+					logger.Info("Conflict adding finalizer, will retry on re-fetch", "pipelineRun", pipelineRun.Name)
+					return ctrl.Result{}, err
+				}
 				logger.Error(err, "Failed to add finalizer", "pipelineRun", pipelineRun.Name)
 				return ctrl.Result{}, err
 			}
@@ -107,6 +115,10 @@ func (r *NotificationServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 		}
 		err = RemoveFinalizerFromPipelineRun(ctx, pipelineRun, r, NotificationPipelineRunFinalizer)
 		if err != nil {
+			if errors.IsConflict(err) {
+				logger.Info("Conflict removing finalizer on ended run, will retry on re-fetch", "pipelineRun", pipelineRun.Name)
+				return ctrl.Result{}, err
+			}
 			logger.Error(err, "Failed to remove finalizer", "pipelineRun", pipelineRun.Name)
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/pipelinerun_helper.go
+++ b/internal/controller/pipelinerun_helper.go
@@ -26,7 +26,7 @@ const AppLabelKey string = "appstudio.openshift.io/application"
 // If finalizer was not added successfully, a non-nil error is returned.
 func AddFinalizerToPipelineRun(ctx context.Context, pipelineRun *tektonv1.PipelineRun, r *NotificationServiceReconciler, finalizer string) error {
 	r.Log.Info("Adding finalizer", "pipelineRun", pipelineRun.Name)
-	patch := client.MergeFrom(pipelineRun.DeepCopy())
+	patch := client.MergeFromWithOptions(pipelineRun.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	if ok := controllerutil.AddFinalizer(pipelineRun, finalizer); ok {
 		err := r.Client.Patch(ctx, pipelineRun, patch)
 		if err != nil {
@@ -41,7 +41,7 @@ func AddFinalizerToPipelineRun(ctx context.Context, pipelineRun *tektonv1.Pipeli
 // If finalizer was not removed successfully, a non-nil error is returned.
 func RemoveFinalizerFromPipelineRun(ctx context.Context, pipelineRun *tektonv1.PipelineRun, r *NotificationServiceReconciler, finalizer string) error {
 	r.Log.Info("Removing finalizer", "pipelineRun", pipelineRun.Name)
-	patch := client.MergeFrom(pipelineRun.DeepCopy())
+	patch := client.MergeFromWithOptions(pipelineRun.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	if ok := controllerutil.RemoveFinalizer(pipelineRun, finalizer); ok {
 		err := r.Client.Patch(ctx, pipelineRun, patch)
 		if err != nil {


### PR DESCRIPTION
Switch AddFinalizerToPipelineRun and
RemoveFinalizerFromPipelineRun to use
MergeFromWithOptions with
MergeFromWithOptimisticLock to include
resourceVersion in finalizer patches. This ensures a 409 conflict is returned if another controller has modified the PipelineRun since the last read, forcing a re-fetch before retry and preventing stale writes from silently wiping concurrently added finalizers.