### PR TITLE
feat(test): add optimistic lock tests

### DIFF
--- a/internal/controller/notificationservice_controller_test.go
+++ b/internal/controller/notificationservice_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -472,6 +473,121 @@ var _ = Describe("NotificationService Controller", func() {
 					Expect(err).ToNot(HaveOccurred())
 					return controllerutil.ContainsFinalizer(createdPipelineRun, NotificationPipelineRunFinalizer)
 				}, timeout, interval).Should(BeTrue())
+			})
+		})
+	})
+
+	Describe("Testing conflict handling during reconciliation", func() {
+		Context("when a patch conflict occurs while adding a finalizer to a running PipelineRun", func() {
+			const conflictAddFinalizerPLRName = "conflict-add-finalizer-plr"
+			It("should return a conflict error and requeue", func() {
+				plr := &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      conflictAddFinalizerPLRName,
+						Namespace: namespace,
+						Labels: map[string]string{
+							PipelineRunTypeLabel: PushPipelineRunTypeValue,
+						},
+					},
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{},
+					},
+				}
+				Expect(k8sClient.Create(ctx, plr)).To(Succeed())
+				DeferCleanup(func() {
+					_ = k8sClient.Delete(ctx, plr)
+				})
+
+				result, err := conflictNsr.Reconcile(ctx, ctrl.Request{
+					NamespacedName: types.NamespacedName{Name: conflictAddFinalizerPLRName, Namespace: namespace},
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsConflict(err)).To(BeTrue())
+				Expect(result).To(Equal(ctrl.Result{}))
+			})
+		})
+
+		Context("when a patch conflict occurs while removing a finalizer from a deleted PipelineRun", func() {
+			const conflictDeletedPLRName = "conflict-deleted-plr"
+			It("should return a conflict error and requeue", func() {
+				plr := &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       conflictDeletedPLRName,
+						Namespace:  namespace,
+						Finalizers: []string{NotificationPipelineRunFinalizer},
+						Labels: map[string]string{
+							PipelineRunTypeLabel: PushPipelineRunTypeValue,
+						},
+					},
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{},
+					},
+				}
+				Expect(k8sClient.Create(ctx, plr)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, plr)).To(Succeed())
+				DeferCleanup(func() {
+					fetchedPlr := &tektonv1.PipelineRun{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{Name: conflictDeletedPLRName, Namespace: namespace}, fetchedPlr); err == nil {
+						controllerutil.RemoveFinalizer(fetchedPlr, NotificationPipelineRunFinalizer)
+						_ = k8sClient.Update(ctx, fetchedPlr)
+					}
+				})
+
+				result, err := conflictNsr.Reconcile(ctx, ctrl.Request{
+					NamespacedName: types.NamespacedName{Name: conflictDeletedPLRName, Namespace: namespace},
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsConflict(err)).To(BeTrue())
+				Expect(result).To(Equal(ctrl.Result{}))
+			})
+		})
+
+		Context("when a patch conflict occurs while removing a finalizer from an ended PipelineRun", func() {
+			const conflictEndedPLRName = "conflict-ended-plr"
+			It("should return a conflict error and requeue", func() {
+				plr := &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       conflictEndedPLRName,
+						Namespace:  namespace,
+						Finalizers: []string{NotificationPipelineRunFinalizer},
+						Labels: map[string]string{
+							PipelineRunTypeLabel:                 PushPipelineRunTypeValue,
+							"appstudio.openshift.io/application": "test-app",
+						},
+					},
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{},
+					},
+				}
+				Expect(k8sClient.Create(ctx, plr)).To(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: conflictEndedPLRName, Namespace: namespace}, plr)).To(Succeed())
+				plr.Status = tektonv1.PipelineRunStatus{
+					Status: v1.Status{
+						Conditions: v1.Conditions{
+							apis.Condition{
+								Status: "False",
+								Type:   apis.ConditionSucceeded,
+								Reason: "Failed",
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Status().Update(ctx, plr)).To(Succeed())
+				DeferCleanup(func() {
+					fetchedPlr := &tektonv1.PipelineRun{}
+					if err := k8sClient.Get(ctx, types.NamespacedName{Name: conflictEndedPLRName, Namespace: namespace}, fetchedPlr); err == nil {
+						controllerutil.RemoveFinalizer(fetchedPlr, NotificationPipelineRunFinalizer)
+						_ = k8sClient.Update(ctx, fetchedPlr)
+						_ = k8sClient.Delete(ctx, fetchedPlr)
+					}
+				})
+
+				result, err := conflictNsr.Reconcile(ctx, ctrl.Request{
+					NamespacedName: types.NamespacedName{Name: conflictEndedPLRName, Namespace: namespace},
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsConflict(err)).To(BeTrue())
+				Expect(result).To(Equal(ctrl.Result{}))
 			})
 		})
 	})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"go/build"
 	"path/filepath"
@@ -32,6 +31,8 @@ import (
 
 	toolkit "github.com/konflux-ci/operator-toolkit/test"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,7 +54,7 @@ var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 var mn, fakeErrorNotify *MockNotifier
-var nsr, fakeErrorNotifyNsr, fakeErrorNsr *NotificationServiceReconciler
+var nsr, fakeErrorNotifyNsr, fakeErrorNsr, conflictNsr *NotificationServiceReconciler
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -62,28 +63,22 @@ func TestControllers(t *testing.T) {
 }
 
 type MockNotifier struct {
-	Counter            int
-	shouldThroughError bool
+	Counter   int
+	notifyErr error
 }
 
 func (mn *MockNotifier) Notify(ctx context.Context, message string) error {
 	mn.Counter++
-	if mn.shouldThroughError {
-		return errors.New("Failed to Notify")
-	}
-	return nil
+	return mn.notifyErr
 }
 
 type clientMock struct {
 	client.Client
-	shouldThroughError bool
+	patchErr error
 }
 
 func (p *clientMock) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	if p.shouldThroughError {
-		return errors.New("Failed to patch")
-	}
-	return nil
+	return p.patchErr
 }
 
 var _ = BeforeEach(func() {
@@ -156,26 +151,33 @@ var _ = BeforeEach(func() {
 	})
 
 	Expect(err).ToNot(HaveOccurred())
-	// Create a mock of notifier
-	mn = &MockNotifier{shouldThroughError: false}
+	mn = &MockNotifier{}
 	nsr = &NotificationServiceReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
 		Log:      k8sManager.GetLogger(),
 		Notifier: mn,
 	}
-	// err = nsr.SetupWithManager(k8sManager)
-	// Expect(err).ToNot(HaveOccurred())
-	fakeErrorNotify = &MockNotifier{shouldThroughError: true}
+	fakeErrorNotify = &MockNotifier{notifyErr: fmt.Errorf("Failed to Notify")}
 	fakeErrorNotifyNsr = &NotificationServiceReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
 		Log:      k8sManager.GetLogger(),
 		Notifier: fakeErrorNotify,
 	}
-	fakeErrorPatchClient := &clientMock{shouldThroughError: true}
+	fakeErrorPatchClient := &clientMock{patchErr: fmt.Errorf("Failed to patch")}
 	fakeErrorNsr = &NotificationServiceReconciler{
 		Client:   fakeErrorPatchClient,
+		Scheme:   k8sManager.GetScheme(),
+		Log:      k8sManager.GetLogger(),
+		Notifier: mn,
+	}
+	conflictPatchClient := &clientMock{
+		Client:   k8sClient,
+		patchErr: apierrors.NewConflict(schema.GroupResource{Group: "tekton.dev", Resource: "pipelineruns"}, "", fmt.Errorf("the object has been modified")),
+	}
+	conflictNsr = &NotificationServiceReconciler{
+		Client:   conflictPatchClient,
 		Scheme:   k8sManager.GetScheme(),
 		Log:      k8sManager.GetLogger(),
 		Notifier: mn,


### PR DESCRIPTION
Add optimistic lock tests to the controller to increase coverage. 
This is to ensure that the controller is able to handle optimistic lock errors.

Assisted-by: Cursor + Opus 4.6