### PR TITLE
ci: fix yaml lint runner label

### DIFF
--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-changes:
     name: Check for relevant changes
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     outputs:
       yaml: ${{ steps.changed-files.outputs.any_changed }}
     steps:


### PR DESCRIPTION
## Description

Fixes #790

This PR updates the YAML lint workflow to use `ubuntu-latest` instead of `ubuntu-slim` for the `check-changes` job.

The workflow already uses `ubuntu-latest` for the `lint` job, and this change makes the runner label consistent across the workflow.

## Validation

- Verified that `.github/workflows/yaml-lint.yaml` now uses `ubuntu-latest` for the `check-changes` job.
- No application code changes.